### PR TITLE
Fix vulnerability in JWE p2c header value

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1217,3 +1217,9 @@ version 8.22.1 (2021-07-01)
 
 version 8.23 (2021-09-23)
     * Adds RSA-OAEP-512 support to RSAEncrypter and RSADecrypter.
+
+version 8.24-wso2v1 (2024-10-29)
+    * The PasswordBasedDecrypter (PBKDF2) must enforce a limit on the maximum
+      allowed JWE "p2c" header value to prevent DoS attacks. This limit is now
+      set to 1 million, taking into account that OWASP recommends 600 thousand
+      iterations for PBKDF2-HMAC-SHA256 (iss 526).

--- a/SECURITY-CHANGELOG.txt
+++ b/SECURITY-CHANGELOG.txt
@@ -62,3 +62,9 @@ version 9.10 (2021-06-05)
       header parameter (iss #424).
     * Prevents StackOverflowError when parsing a JOSE header with a very large
       number of nested JOSE objects (iss #425).
+
+version 8.24-wso2v1 (2024-10-29)
+    * The PasswordBasedDecrypter (PBKDF2) must enforce a limit on the maximum
+      allowed JWE "p2c" header value to prevent DoS attacks. This limit is now
+      set to 1 million, taking into account that OWASP recommends 600 thousand
+      iterations for PBKDF2-HMAC-SHA256 (iss 526).

--- a/src/main/java/com/nimbusds/jose/HeaderParameterNames.java
+++ b/src/main/java/com/nimbusds/jose/HeaderParameterNames.java
@@ -1,0 +1,294 @@
+package com.nimbusds.jose;
+
+import com.nimbusds.jwt.JWTClaimNames;
+
+/**
+ * JSON Web Signature (JWS) and JSON Web Encryption (JWE) header parameter
+ * names.
+ *
+ * <p>
+ * The header parameter names defined in
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7515">RFC 7515</a> (JWS),
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7516">RFC 7516</a> (JWE)
+ * and other JOSE related standards are tracked in a
+ * <a href=
+ * "https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-header-parameters">JWS
+ * and JWE header parameters registry</a> administered by IANA.
+ *
+ * <p>
+ * Note, some header parameters here may not be present in the IANA registry
+ * (yet).
+ *
+ * @author Nathaniel Hart
+ * @author Vladimir Dzhuvinov
+ * @version 2024-06-27
+ */
+public final class HeaderParameterNames {
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Generic JWS and JWE Header Parameters
+    ////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Used in {@link JWSHeader} and {@link JWEHeader}.
+     *
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.1">RFC 7515
+     *      "alg" (JWS Algorithm) Header Parameter</a>
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.1">RFC 7516
+     *      "alg" (JWE Algorithm) Header Parameter</a>
+     */
+    public static final String ALGORITHM = "alg";
+
+    /**
+     * Used in {@link JWEHeader}.
+     *
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.2">RFC 7516
+     *      "enc" (Encryption Algorithm) Header Parameter</a>
+     */
+    public static final String ENCRYPTION_ALGORITHM = "enc";
+
+    /**
+     * Used in {@link JWEHeader}.
+     *
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.3">RFC 7516
+     *      "zip" (Compression Algorithm) Header Parameter</a>
+     */
+    public static final String COMPRESSION_ALGORITHM = "zip";
+
+    /**
+     * Used in {@link JWSHeader} and {@link JWEHeader}.
+     *
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.2">RFC 7515
+     *      "jku" (JWK Set URL) Header Parameter</a>
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.4">RFC 7516
+     *      "jku" (JWK Set URL) Header Parameter</a>
+     */
+    public static final String JWK_SET_URL = "jku";
+
+    /**
+     * Used in {@link JWSHeader} and {@link JWEHeader}.
+     *
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.3">RFC 7515
+     *      "jwk" (JSON Web Key) Header Parameter</a>
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.5">RFC 7516
+     *      "jwk" (JSON Web Key) Header Parameter</a>
+     */
+    public static final String JWK = "jwk";
+
+    /**
+     * Used in {@link JWSHeader} and {@link JWEHeader}.
+     *
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.4">RFC 7515
+     *      "kid" (Key ID) Header Parameter</a>
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.6">RFC 7516
+     *      "kid" (Key ID) Header Parameter</a>
+     */
+    public static final String KEY_ID = "kid";
+
+    /**
+     * Used in {@link JWSHeader} and {@link JWEHeader}.
+     *
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.5">RFC 7515
+     *      "x5u" (X.509 Certificate URL) Header Parameter</a>
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.7">RFC 7516
+     *      "x5u" (X.509 Certificate URL) Header Parameter</a>
+     */
+    public static final String X_509_CERT_URL = "x5u";
+
+    /**
+     * Used in {@link JWSHeader} and {@link JWEHeader}.
+     *
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.6">RFC 7515
+     *      "x5c" (X.509 Certificate Chain) Header Parameter</a>
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.8">RFC 7516
+     *      "x5c" (X.509 Certificate Chain) Header Parameter</a>
+     */
+    public static final String X_509_CERT_CHAIN = "x5c";
+
+    /**
+     * Used in {@link JWSHeader} and {@link JWEHeader}.
+     *
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.7">RFC 7515
+     *      "x5t" (X.509 Certificate SHA-1 Thumbprint) Header Parameter</a>
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.9">RFC 7516
+     *      "x5t" (X.509 Certificate SHA-1 Thumbprint) Header Parameter</a>
+     */
+    public static final String X_509_CERT_SHA_1_THUMBPRINT = "x5t";
+
+    /**
+     * Used in {@link JWSHeader} and {@link JWEHeader}.
+     *
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.8">RFC 7515
+     *      "x5t#S256" (X.509 Certificate SHA-256 Thumbprint) Header Parameter</a>
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.10">RFC 7516
+     *      "x5t#S256" (X.509 Certificate SHA-256 Thumbprint) Header Parameter</a>
+     */
+    public static final String X_509_CERT_SHA_256_THUMBPRINT = "x5t#S256";
+
+    /**
+     * Used in {@link JWSHeader} and {@link JWEHeader}.
+     *
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.9">RFC 7515
+     *      "typ" (Type) Header Parameter</a>
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.11">RFC 7516
+     *      "typ" (Type) Header Parameter</a>
+     */
+    public static final String TYPE = "typ";
+
+    /**
+     * Used in {@link JWSHeader} and {@link JWEHeader}.
+     *
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.10">RFC 7515
+     *      "cty" (Content Type) Header Parameter</a>
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.12">RFC 7516
+     *      "cty" (Content Type) Header Parameter</a>
+     */
+    public static final String CONTENT_TYPE = "cty";
+
+    /**
+     * Used in {@link JWSHeader} and {@link JWEHeader}.
+     *
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.11">RFC 7515
+     *      "crit" (Critical) Header Parameter</a>
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.13">RFC 7516
+     *      "crit" (Critical) Header Parameter</a>
+     */
+    public static final String CRITICAL = "crit";
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Algorithm-Specific Header Parameters
+    ////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Used in {@link JWEHeader} with ECDH key agreement.
+     *
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7518#section-4.6.1.1">RFC 7518
+     *      "epk" (Ephemeral Public Key) Header Parameter</a>
+     */
+    public static final String EPHEMERAL_PUBLIC_KEY = "epk";
+
+    /**
+     * Used in {@link JWEHeader} with ECDH key agreement.
+     *
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7518#section-4.6.1.2">RFC 7518
+     *      "apu" (Agreement PartyUInfo) Header Parameter</a>
+     */
+    public static final String AGREEMENT_PARTY_U_INFO = "apu";
+
+    /**
+     * Used in {@link JWEHeader} with ECDH key agreement.
+     *
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7518#section-4.6.1.3">RFC 7518
+     *      "apv" (Agreement PartyVInfo) Header Parameter</a>
+     */
+    public static final String AGREEMENT_PARTY_V_INFO = "apv";
+
+    /**
+     * Used in {@link JWEHeader} with AES GCN key encryption.
+     *
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7518#section-4.7.1.1">RFC 7518
+     *      "iv" (Initialization Vector) Header Parameter</a>
+     */
+    public static final String INITIALIZATION_VECTOR = "iv";
+
+    /**
+     * Used in {@link JWEHeader} with AES GCN key encryption.
+     *
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7518#section-4.7.1.2">RFC 7518
+     *      "tag" (Authentication Tag) Header Parameter</a>
+     */
+    public static final String AUTHENTICATION_TAG = "tag";
+
+    /**
+     * Used in {@link JWEHeader} with PBES2 key encryption.
+     *
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7518#section-4.8.1.1">RFC 7518
+     *      "p2s" (PBES2 Salt Input) Header Parameter</a>
+     */
+    public static final String PBES2_SALT_INPUT = "p2s";
+
+    /**
+     * Used in {@link JWEHeader} with PBES2 key encryption.
+     *
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7518#section-4.8.1.2">RFC 7518
+     *      "p2c" (PBES2 Count) Header Parameter</a>
+     */
+    public static final String PBES2_COUNT = "p2c";
+
+    /**
+     * Used in {@link JWEHeader} with ECDH-1PU key agreement.
+     *
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04#section-2.2.1">"skid"
+     *      Header Parameter</a>
+     */
+    public static final String SENDER_KEY_ID = "skid";
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // RFC 7797 (JWS Unencoded Payload Option) Header Parameters
+    ////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Used in {@link JWSHeader} with unencoded {@link Payload}.
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc7797#section-3">RFC
+     *      7797 "b64" (base64url-encode payload) Header Parameter</a>
+     */
+    public static final String BASE64_URL_ENCODE_PAYLOAD = "b64";
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // RFC 7519 (JWT) claims replicated as JWE header parameters
+    ////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Used in {@link JWEHeader} where the issuer claim is replicated as a
+     * header parameter.
+     */
+    public static final String ISSUER = JWTClaimNames.ISSUER;
+
+    /**
+     * Used in {@link JWEHeader} where the issuer claim is replicated as a
+     * header parameter.
+     */
+    public static final String SUBJECT = JWTClaimNames.SUBJECT;
+
+    /**
+     * Used in {@link JWEHeader} where the issuer claim is replicated as a
+     * header parameter.
+     */
+    public static final String AUDIENCE = JWTClaimNames.AUDIENCE;
+
+    private HeaderParameterNames() {
+    }
+}

--- a/src/main/java/com/nimbusds/jose/crypto/PasswordBasedDecrypter.java
+++ b/src/main/java/com/nimbusds/jose/crypto/PasswordBasedDecrypter.java
@@ -18,14 +18,14 @@
 package com.nimbusds.jose.crypto;
 
 
-import java.util.Set;
-import javax.crypto.SecretKey;
-
 import com.nimbusds.jose.*;
 import com.nimbusds.jose.crypto.impl.*;
 import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jose.util.StandardCharset;
 import net.jcip.annotations.ThreadSafe;
+
+import javax.crypto.SecretKey;
+import java.util.Set;
 
 
 /**
@@ -60,10 +60,17 @@ import net.jcip.annotations.ThreadSafe;
  * </ul>
  *
  * @author Vladimir Dzhuvinov
- * @version 2016-07-26
+ * @author Egor Puzanov
+ * @version 2023-12-03
  */
 @ThreadSafe
 public class PasswordBasedDecrypter extends PasswordBasedCryptoProvider implements JWEDecrypter, CriticalHeaderParamsAware {
+
+
+	/**
+	 * The maximum allowed iteration count (1 million).
+	 */
+	public static final int MAX_ALLOWED_ITERATION_COUNT = 1_000_000;
 
 
 	/**
@@ -142,6 +149,10 @@ public class PasswordBasedDecrypter extends PasswordBasedCryptoProvider implemen
 		}
 
 		final int iterationCount = header.getPBES2Count();
+
+		if (iterationCount > MAX_ALLOWED_ITERATION_COUNT) {
+			throw new JOSEException("The JWE p2c header exceeds the maximum allowed " + MAX_ALLOWED_ITERATION_COUNT + " count");
+		}
 
 		critPolicy.ensureHeaderPasses(header);
 

--- a/src/main/java/com/nimbusds/jose/util/JSONObjectUtils.java
+++ b/src/main/java/com/nimbusds/jose/util/JSONObjectUtils.java
@@ -446,6 +446,17 @@ public class JSONObjectUtils {
 		return new Base64URL(value);
 	}
 
+	/**
+	 * Serialises the specified string to a JSON string.
+	 *
+	 * @param string The string. Must not be {@code null}.
+	 *
+	 * @return The string as JSON string.
+	 */
+	public static String toJSONString(final String string) {
+		
+		return "\"" + JSONObject.escape(string) + "\"";
+	}
 
 	/**
 	 * Prevents public instantiation.

--- a/src/main/java/com/nimbusds/jwt/JWTClaimNames.java
+++ b/src/main/java/com/nimbusds/jwt/JWTClaimNames.java
@@ -1,0 +1,66 @@
+package com.nimbusds.jwt;
+
+/**
+ * JSON Web Token (JWT) claim names. The claim names defined in
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7519">RFC 7519</a> (JWT)
+ * and other standards, such as OpenID Connect, are tracked in a
+ * <a href="https://www.iana.org/assignments/jwt/jwt.xhtml#claims">JWT claims
+ * registry</a> administered by IANA.
+ *
+ * @author Nathaniel Hart
+ * @version 2021-07-11
+ */
+public final class JWTClaimNames {
+
+    /**
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1">RFC 7519
+     *      "iss" (Issuer) Claim</a>
+     */
+    public static final String ISSUER = "iss";
+
+    /**
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2">RFC 7519
+     *      "sub" (Subject) Claim</a>
+     */
+    public static final String SUBJECT = "sub";
+
+    /**
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3">RFC 7519
+     *      "aud" (Audience) Claim</a>
+     */
+    public static final String AUDIENCE = "aud";
+
+    /**
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4">RFC 7519
+     *      "exp" (Expiration Time) Claim</a>
+     */
+    public static final String EXPIRATION_TIME = "exp";
+
+    /**
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5">RFC 7519
+     *      "nbf" (Not Before) Claim</a>
+     */
+    public static final String NOT_BEFORE = "nbf";
+
+    /**
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.6">RFC 7519
+     *      "iat" (Issued At) Claim</a>
+     */
+    public static final String ISSUED_AT = "iat";
+
+    /**
+     * @see <a href=
+     *      "https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.7">RFC 7519
+     *      "jti" (JWT ID) Claim</a>
+     */
+    public static final String JWT_ID = "jti";
+
+    private JWTClaimNames() {
+    }
+}

--- a/src/test/java/com/nimbusds/jose/HeaderParameterNamesTest.java
+++ b/src/test/java/com/nimbusds/jose/HeaderParameterNamesTest.java
@@ -1,0 +1,47 @@
+package com.nimbusds.jose;
+
+import junit.framework.TestCase;
+
+import static com.nimbusds.jose.HeaderParameterNames.*;
+
+/**
+ * Tests the correctness of the Header Parameter Constants.
+ *
+ * @author Nathaniel Hart
+ * @version 2024-06-29
+ */
+public class HeaderParameterNamesTest extends TestCase {
+
+    public void testConstantValues() {
+
+        assertEquals("alg", ALGORITHM);
+        assertEquals("enc", ENCRYPTION_ALGORITHM);
+        assertEquals("zip", COMPRESSION_ALGORITHM);
+        assertEquals("jku", JWK_SET_URL);
+        assertEquals("jwk", JWK);
+        assertEquals("kid", KEY_ID);
+        assertEquals("x5u", X_509_CERT_URL);
+        assertEquals("x5c", X_509_CERT_CHAIN);
+        assertEquals("x5t", X_509_CERT_SHA_1_THUMBPRINT);
+        assertEquals("x5t#S256", X_509_CERT_SHA_256_THUMBPRINT);
+        assertEquals("typ", TYPE);
+        assertEquals("cty", CONTENT_TYPE);
+        assertEquals("crit", CRITICAL);
+
+        assertEquals("epk", EPHEMERAL_PUBLIC_KEY);
+        assertEquals("apu", AGREEMENT_PARTY_U_INFO);
+        assertEquals("apv", AGREEMENT_PARTY_V_INFO);
+
+        assertEquals("iv", INITIALIZATION_VECTOR);
+        assertEquals("tag", AUTHENTICATION_TAG);
+
+        assertEquals("p2s", PBES2_SALT_INPUT);
+        assertEquals("p2c", PBES2_COUNT);
+
+        assertEquals("b64", BASE64_URL_ENCODE_PAYLOAD);
+
+        assertEquals("iss", ISSUER);
+        assertEquals("sub", SUBJECT);
+        assertEquals("aud", AUDIENCE);
+    }
+}

--- a/src/test/java/com/nimbusds/jose/crypto/PBES2Test.java
+++ b/src/test/java/com/nimbusds/jose/crypto/PBES2Test.java
@@ -20,10 +20,22 @@ package com.nimbusds.jose.crypto;
 
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import junit.framework.TestCase;
 
 import com.nimbusds.jose.*;
 import com.nimbusds.jose.crypto.bc.BouncyCastleProviderSingleton;
-import junit.framework.TestCase;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jose.util.JSONObjectUtils;
+import com.nimbusds.jose.util.StandardCharset;
+import net.minidev.json.JSONObject;
 
 
 /**
@@ -122,6 +134,8 @@ public class PBES2Test extends TestCase {
 
 		assertEquals(8, PasswordBasedEncrypter.MIN_SALT_LENGTH);
 		assertEquals(1000, PasswordBasedEncrypter.MIN_RECOMMENDED_ITERATION_COUNT);
+
+		assertEquals(1_000_000, PasswordBasedDecrypter.MAX_ALLOWED_ITERATION_COUNT);
 	}
 
 
@@ -235,5 +249,40 @@ public class PBES2Test extends TestCase {
 		String expectedPlainText = "{\"keys\":[{\"kty\":\"oct\",\"kid\":\"77c7e2b8-6e13-45cf-8672-617b5b45243a\",\"use\":\"enc\",\"alg\":\"A128GCM\",\"k\":\"XctOhJAkA-pD9Lh7ZgW_2A\"},{\"kty\":\"oct\",\"kid\":\"81b20965-8332-43d9-a468-82160ad91ac8\",\"use\":\"enc\",\"alg\":\"A128KW\",\"k\":\"GZy6sIZ6wl9NJOKB-jnmVQ\"},{\"kty\":\"oct\",\"kid\":\"18ec08e1-bfa9-4d95-b205-2b4dd1d4321d\",\"use\":\"enc\",\"alg\":\"A256GCMKW\",\"k\":\"qC57l_uxcm7Nm3K-ct4GFjx8tM1U8CZ0NLBvdQstiS8\"}]}";
 
 		assertEquals(expectedPlainText, jweObject.getPayload().toString());
+	}
+	
+	
+	public void testPBES2_rejectZero_p2c()
+		throws Exception {
+		
+		final String password = "secret";
+		final String plaintext = "Hello world!";
+		
+		JWEObject jweObject = new JWEObject(new JWEHeader.Builder(JWEAlgorithm.PBES2_HS256_A128KW, EncryptionMethod.A128GCM).build(), new Payload(plaintext));
+		
+		PasswordBasedEncrypter encrypter = new PasswordBasedEncrypter(password, 16, 8192);
+		encrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+		jweObject.encrypt(encrypter);
+		String jwe = jweObject.serialize();
+		
+		// Modify header
+		JSONObject modifiedHeaderJSONObject = new JSONObject();
+		modifiedHeaderJSONObject.putAll(jweObject.getHeader().toJSONObject());
+		modifiedHeaderJSONObject.put(HeaderParameterNames.PBES2_COUNT, 0);
+		Base64URL modifiedHeader = Base64URL.encode(modifiedHeaderJSONObject.toJSONString());
+		
+		jwe = jwe.substring(jwe.indexOf('.'));
+		jwe = modifiedHeader + jwe;
+		
+		jweObject = JWEObject.parse(jwe);
+		
+		PasswordBasedDecrypter decrypter = new PasswordBasedDecrypter(password);
+		decrypter.getJCAContext().setContentEncryptionProvider(BouncyCastleProviderSingleton.getInstance());
+		try {
+			jweObject.decrypt(decrypter);
+			fail();
+		} catch (JOSEException e) {
+			assertEquals("Missing JWE \"p2c\" header parameter", e.getMessage());
+		}
 	}
 }

--- a/src/test/java/com/nimbusds/jwt/JWTClaimNamesTest.java
+++ b/src/test/java/com/nimbusds/jwt/JWTClaimNamesTest.java
@@ -1,0 +1,24 @@
+package com.nimbusds.jwt;
+
+import junit.framework.TestCase;
+
+import static com.nimbusds.jwt.JWTClaimNames.*;
+
+/**
+ * Tests the correctness of the JWT Claim Name Constants.
+ *
+ * @author Nathaniel Hart
+ * @version 2021-06-15
+ */
+public class JWTClaimNamesTest extends TestCase {
+
+    public void testPayloadClaimValues() {
+        assertEquals("iss", ISSUER);
+        assertEquals("sub", SUBJECT);
+        assertEquals("aud", AUDIENCE);
+        assertEquals("exp", EXPIRATION_TIME);
+        assertEquals("nbf", NOT_BEFORE);
+        assertEquals("iat", ISSUED_AT);
+        assertEquals("jti", JWT_ID);
+    }
+}


### PR DESCRIPTION
## Purpose

Address the security vulnerability in JWE p2c header value


## Approach

- Set maximum allowed iteration count limit in the header value
- Add test cases to verify the fix
- Add missing test files from the 9.x version to the repo to fix test cases 